### PR TITLE
implements shifter method and partitions code

### DIFF
--- a/nonlinear-equation-solvers/fortran/nlsolvers.for
+++ b/nonlinear-equation-solvers/fortran/nlsolvers.for
@@ -63,14 +63,7 @@ module nlsolvers
             type(nls_conf), intent(in), optional :: opts
 
             call bracket_check (lb, ub, fp)
-
-            if ( present(opts) ) then
-                t     = opts % tol
-                maxit = opts % max_iter
-            else
-                t     = TOL
-                maxit = MAX_ITER
-            end if
+            call optset(t, maxit, opts)
 
             ! checks bounds
             if (lb < ub) then
@@ -112,14 +105,7 @@ module nlsolvers
             type(nls_conf), intent(in), optional :: opts
 
             call bracket_check (lb, ub, fp)
-
-            if ( present(opts) ) then
-                t     = opts % tol
-                maxit = opts % max_iter
-            else
-                t     = TOL
-                maxit = MAX_ITER
-            end if
+            call optset(t, maxit, opts)
 
             ! checks bounds
             if (lb < ub) then
@@ -174,6 +160,25 @@ module nlsolvers
 
             if ( fp(lb) * fp(ub) > 0.0_real64 ) then
                 error stop errmsg
+            end if
+
+            return
+        end subroutine
+
+
+        subroutine optset (tolerance, maxiter, opts)
+            ! Synopsis:
+            ! Sets the tolerance and maximum number of iterations options.
+            real(kind = real64), intent(out) :: tolerance
+            integer(kind = int32), intent(out) :: maxiter
+            type(nls_conf), intent(in), optional :: opts
+
+            if ( present(opts) ) then
+                tolerance = opts % tol
+                maxiter   = opts % max_iter
+            else
+                tolerance = TOL
+                maxiter   = MAX_ITER
             end if
 
             return

--- a/nonlinear-equation-solvers/fortran/nlsolvers.for
+++ b/nonlinear-equation-solvers/fortran/nlsolvers.for
@@ -69,15 +69,7 @@ module nlsolvers
             n = 1
             x = 0.5_real64 * (a + b)
             do while ( n /= maxit .and. abs( fp(x) ) > t )
-
-                ! selects the bracketing interval
-                if ( fp(a) * fp(x) < 0.0_real64 ) then
-                    b = x
-                else
-                    a = x
-                end if
-
-                x = 0.5_real64 * (a + b)
+                call bisector (a, b, x, fp)
                 n = n + 1
             end do
 
@@ -85,6 +77,27 @@ module nlsolvers
 
             return
         end function
+
+
+        subroutine bisector (lb, ub, x, fp)
+            ! Synopsis:
+            ! Bisects the bracketing interval [lb, ub] and returns
+            ! its middle value as an estimate of the root of the
+            ! nonlinear function f(x). As a side-effect the function
+            ! updates the bounds of the bracketing interval.
+            real(kind = real64), intent(inout) :: lb, ub
+            real(kind = real64), intent(inout) :: x
+            procedure(fun), pointer :: fp
+
+            if ( fp(lb) * fp(x) < 0.0_real64 ) then
+                ub = x
+            else
+                lb = x
+            end if
+
+            x = 0.5_real64 * (lb + ub)
+            return
+        end subroutine
 
 
         function regfal (lb, ub, fp, opts) result(x)    ! Regula Falsi
@@ -103,15 +116,7 @@ module nlsolvers
             n = 1
             x = ( a * fp(b) - b * fp(a) ) / ( fp(b) - fp(a) )
             do while ( n /= maxit .and. abs( fp(x) ) > t )
-
-                ! selects the bracketing interval
-                if ( fp(a) * fp(x) < 0.0_real64 ) then
-                    b = x
-                else
-                    a = x
-                end if
-
-                x = ( a * fp(b) - b * fp(a) ) / ( fp(b) - fp(a) )
+                call interp (a, b, x, fp)
                 n = n + 1
             end do
 
@@ -119,6 +124,24 @@ module nlsolvers
 
             return
         end function
+
+
+        subroutine interp (lb, ub, x, fp)
+            ! Synopsis:
+            ! As bisector but estimates the root via linear interpolation.
+            real(kind = real64), intent(inout) :: lb, ub
+            real(kind = real64), intent(inout) :: x
+            procedure(fun), pointer :: fp
+
+            if ( fp(lb) * fp(x) < 0.0_real64 ) then
+                ub = x
+            else
+                lb = x
+            end if
+
+            x = ( lb * fp(ub) - ub * fp(lb) ) / ( fp(ub) - fp(lb) )
+            return
+        end subroutine
 
 
         subroutine report(n)

--- a/nonlinear-equation-solvers/fortran/nlsolvers.for
+++ b/nonlinear-equation-solvers/fortran/nlsolvers.for
@@ -61,8 +61,9 @@ module nlsolvers
             integer(kind = int32):: n, maxit            ! count && max iter
             real(kind = real64):: t                     ! tolerance
             type(nls_conf), intent(in), optional :: opts
+            character(len=*), parameter :: nm = "Bisection"
 
-            call bracket_check (lb, ub, fp)
+            call bracket_check (lb, ub, fp, nm)
             call bounds_check  (lb, ub, a, b)
             call optset(t, maxit, opts)
 
@@ -73,7 +74,7 @@ module nlsolvers
                 n = n + 1
             end do
 
-            call report (n)
+            call report (n, nm)
 
             return
         end function
@@ -108,8 +109,9 @@ module nlsolvers
             integer(kind = int32):: n, maxit            ! count && max iter
             real(kind = real64):: t                     ! tolerance
             type(nls_conf), intent(in), optional :: opts
+            character(len=*), parameter :: nm = "Regula Falsi"
 
-            call bracket_check (lb, ub, fp)
+            call bracket_check (lb, ub, fp, nm)
             call bounds_check  (lb, ub, a, b)
             call optset(t, maxit, opts)
 
@@ -120,7 +122,7 @@ module nlsolvers
                 n = n + 1
             end do
 
-            call report (n)
+            call report (n, nm)
 
             return
         end function
@@ -144,10 +146,12 @@ module nlsolvers
         end subroutine
 
 
-        subroutine report(n)
+        subroutine report (n, name)
             integer(kind = int32), intent(in) :: n
+            character(len=*), intent(in) :: name
 
             if (n /= MAX_ITER) then
+                print *, name // " Method: "
                 print *, "solution found in ", n, " iterations"
             else
                 print *, "maximum number of iterations has been " // &
@@ -158,15 +162,16 @@ module nlsolvers
         end subroutine
 
 
-        subroutine bracket_check (lb, ub, fp)
+        subroutine bracket_check (lb, ub, fp, name)
             ! complains if there's no root in given interval [lb, ub].
             real(kind = real64), intent(in) :: lb, ub
             procedure(fun), pointer :: fp
+            character(len=*), intent(in) :: name
             character(len=*), parameter :: errmsg = &
-                & "no root exists in given interval"
+                & "No root exists in given interval"
 
             if ( fp(lb) * fp(ub) > 0.0_real64 ) then
-                error stop errmsg
+                error stop (name // " " // new_line('N') // errmsg)
             end if
 
             return

--- a/nonlinear-equation-solvers/fortran/nlsolvers.for
+++ b/nonlinear-equation-solvers/fortran/nlsolvers.for
@@ -102,14 +102,24 @@ module nlsolvers
         end function
 
 
-        function regfal (lb, ub, fp) result(x)          ! Regula Falsi
+        function regfal (lb, ub, fp, opts) result(x)    ! Regula Falsi
             real(kind = real64), intent(in) :: lb, ub   ! [low, up] bounds
             procedure(fun), pointer :: fp               ! f(x)
             real(kind = real64):: a, b                  ! bounds aliases
             real(kind = real64):: x                     ! root approximate
-            integer(kind = int32):: n                   ! iterations
+            integer(kind = int32):: n, maxit            ! count && max iter
+            real(kind = real64):: t                     ! tolerance
+            type(nls_conf), intent(in), optional :: opts
 
             call bracket_check (lb, ub, fp)
+
+            if ( present(opts) ) then
+                t     = opts % tol
+                maxit = opts % max_iter
+            else
+                t     = TOL
+                maxit = MAX_ITER
+            end if
 
             ! checks bounds
             if (lb < ub) then
@@ -122,7 +132,7 @@ module nlsolvers
 
             n = 1
             x = ( a * fp(b) - b * fp(a) ) / ( fp(b) - fp(a) )
-            do while ( n /= MAX_ITER .and. abs( fp(x) ) > TOL )
+            do while ( n /= maxit .and. abs( fp(x) ) > t )
 
                 ! selects the bracketing interval
                 if ( fp(a) * fp(x) < 0.0_real64 ) then

--- a/nonlinear-equation-solvers/fortran/nlsolvers.for
+++ b/nonlinear-equation-solvers/fortran/nlsolvers.for
@@ -63,16 +63,8 @@ module nlsolvers
             type(nls_conf), intent(in), optional :: opts
 
             call bracket_check (lb, ub, fp)
+            call bounds_check  (lb, ub, a, b)
             call optset(t, maxit, opts)
-
-            ! checks bounds
-            if (lb < ub) then
-                a = lb
-                b = ub
-            else
-                a = ub
-                b = lb
-            end if
 
             n = 1
             x = 0.5_real64 * (a + b)
@@ -105,16 +97,8 @@ module nlsolvers
             type(nls_conf), intent(in), optional :: opts
 
             call bracket_check (lb, ub, fp)
+            call bounds_check  (lb, ub, a, b)
             call optset(t, maxit, opts)
-
-            ! checks bounds
-            if (lb < ub) then
-                a = lb
-                b = ub
-            else
-                a = ub
-                b = lb
-            end if
 
             n = 1
             x = ( a * fp(b) - b * fp(a) ) / ( fp(b) - fp(a) )
@@ -179,6 +163,23 @@ module nlsolvers
             else
                 tolerance = TOL
                 maxiter   = MAX_ITER
+            end if
+
+            return
+        end subroutine
+
+
+        subroutine bounds_check (lb, ub, a, b)
+            ! Synopsis: Ensures the lower bound is less than the upper one.
+            real(kind = real64), intent(in) :: lb, ub
+            real(kind = real64), intent(out) :: a, b
+
+            if (lb < ub) then
+                a = lb
+                b = ub
+            else
+                a = ub
+                b = lb
             end if
 
             return

--- a/nonlinear-equation-solvers/fortran/test_solvers.for
+++ b/nonlinear-equation-solvers/fortran/test_solvers.for
@@ -48,13 +48,13 @@ end module
 
 program tests
     use, intrinsic :: iso_fortran_env, only: real64
-    use nlsolvers, only: bisect, regfal, nls_conf
+    use nlsolvers, only: bisect, regfal, shifter, nls_conf
     use objfun, only: fun
     implicit none
     type(nls_conf) :: opts
     procedure(fun), pointer :: fp => null()
     real(kind = real64) :: lb, ub
-    real(kind = real64) :: x1, x2
+    real(kind = real64) :: x1, x2, x3
 
     ! sets the tolerance and maximum number of iterations of the solver
     opts % tol      = 1.0e-12_real64
@@ -71,10 +71,11 @@ program tests
     ! solves for the root of f(x) numerically
     x1 = bisect (lb, ub, fp, opts)      ! Bisection
     x2 = regfal (lb, ub, fp, opts)      ! Regula Falsi
+    x3 = shifter(lb, ub, fp, opts)      ! Shifter Method
 
 
-    print *, "x: ", x1, x2
-    print *, "f(x): ", fp(x1), fp(x2)
+    print *, "x: ", x1, x2, x3
+    print *, "f(x): ", fp(x1), fp(x2), fp(x3)
 
 
 !   tests for non-enclosing intervals

--- a/nonlinear-equation-solvers/fortran/test_solvers.for
+++ b/nonlinear-equation-solvers/fortran/test_solvers.for
@@ -48,25 +48,29 @@ end module
 
 program tests
     use, intrinsic :: iso_fortran_env, only: real64
-    use nlsolvers, only: bisect, regfal
+    use nlsolvers, only: bisect, regfal, nls_conf
     use objfun, only: fun
     implicit none
+    type(nls_conf) :: opts
     procedure(fun), pointer :: fp => null()
     real(kind = real64) :: lb, ub
     real(kind = real64) :: x1, x2
 
+    ! sets the tolerance and maximum number of iterations of the solver
+    opts % tol      = 1.0e-12_real64
+    opts % max_iter = 256
 
     ! defines the (root) bracketing interval [lb, ub]
-    lb = 2.0e-2_real64
-    ub = 7.0e-2_real64
+    lb = 1.0e-2_real64
+    ub = 9.0e-2_real64
 
 
     fp => fun   !< associates procedure pointer to f(x) >!
 
 
     ! solves for the root of f(x) numerically
-    x1 = bisect (lb, ub, fp)    ! Bisection
-    x2 = regfal (lb, ub, fp)    ! Regula Falsi
+    x1 = bisect (lb, ub, fp, opts)      ! Bisection
+    x2 = regfal (lb, ub, fp)            ! Regula Falsi
 
 
     print *, "x: ", x1, x2

--- a/nonlinear-equation-solvers/fortran/test_solvers.for
+++ b/nonlinear-equation-solvers/fortran/test_solvers.for
@@ -70,7 +70,7 @@ program tests
 
     ! solves for the root of f(x) numerically
     x1 = bisect (lb, ub, fp, opts)      ! Bisection
-    x2 = regfal (lb, ub, fp)            ! Regula Falsi
+    x2 = regfal (lb, ub, fp, opts)      ! Regula Falsi
 
 
     print *, "x: ", x1, x2

--- a/nonlinear-equation-solvers/matlab/bisect.m
+++ b/nonlinear-equation-solvers/matlab/bisect.m
@@ -18,75 +18,94 @@
 % [0] A Gilat and V Subramanian, Numerical Methods for Engineers and
 %    Scientists: An Introduction with Applications using MATLAB
 % [1] A Gilat, MATLAB: An Introduction with Applications, 6th edition
-%
+% [2] www.mathworks.com/help/matlab/matlab_prog/nested-functions.html
 
 
 function x = bisect(a, b, f, opt)
-%    Synopsis:
-%    Bisection Method. Finds the root of the function f(x) enclosed by
-%    the interval [a, b].
-%
-%    inputs:
-%    a            lower bound
-%    b            upper bound
-%    f            nonlinear function, f(x)
-%
-%    output:
-%    x            approximate value of the root if successful.
+    % Synopsis:
+    % Bisection Method. Finds the root of the function f(x) enclosed by
+    % the interval [a, b].
+    %
+    % inputs:
+    % a            lower bound
+    % b            upper bound
+    % f            nonlinear function, f(x)
+    % opt          optional, configuration struct {tolerance, max_iters}
+    %
+    % output:
+    % x            approximate value of the root if successful.
 
 
-% sets default values for the tolerance and maximum number of iterations
-TOL      = 1.0e-8;
-MAX_ITER = 100;
+    % sets default values for the tolerance and max number of iterations
+    TOL      = 1.0e-8;
+    MAX_ITER = 100;
 
-if ( exist('opt', 'var') )
-    % uses configuration struct if passed
-    TOL      = opt.tol;
-    MAX_ITER = opt.max_iter;
-end
+    optset
+    check_bounds
+    check_bracket
 
-if (a > b)
-    % bounds check
-    up = a;
-    a  = b;
-    b  = up;
-end
+    n = 1;
+    x = 0.5 * (a + b);
+    while ( n ~= MAX_ITER && abs( f(x) ) > TOL )
 
+        % updates the bracketing interval
+        if ( f(a) * f(x) < 0 )
+            b = x;
+        else
+            a = x;
+        end
 
-if ( f(a) * f(b) > 0 )
-    % complains if there's no root in the given interval
-    errID  = 'NonlinearSolver:BracketingException';
-    errMSG = 'No roots exists in the given interval [a, b]';
-    except = MException(errID, errMSG);
-    throw(except);
-    return
-end
-
-
-n = 1;
-x = 0.5 * (a + b);
-while ( n ~= MAX_ITER && abs( f(x) ) > TOL )
-
-    % updates the bracketing interval
-    if ( f(a) * f(x) < 0 )
-        b = x;
-    else
-        a = x;
+        x = 0.5 * (a + b);
+        n = n + 1;
     end
 
-    x = 0.5 * (a + b);
-    n = n + 1;
+    report
+    return
+
+
+    %```nested functions:```%
+    function optset
+        % Synopsis: Uses configuration struct if provided by user.
+        if ( exist('opt', 'var') )
+            TOL      = opt.tol;
+            MAX_ITER = opt.max_iter;
+        end
+    end
+
+
+    function check_bounds
+        % Synopsis: Ensures the lower bound is less than the upper bound.
+        if (a > b)
+            up = a;
+            a  = b;
+            b  = up;
+        end
+    end
+
+
+    function check_bracket
+        % Synopsis: Complains if there's no root in the given interval.
+        if ( f(a) * f(b) > 0 )
+            errID  = 'NonlinearSolver:BracketingException';
+            errMSG = 'No roots exists in the given interval [a, b]';
+            except = MException(errID, errMSG);
+            throw(except);
+        end
+    end
+
+
+    function report
+        % Synopsis: Reports to the user if the method has been successful.
+        if ( n ~= MAX_ITER )
+            fprintf('>> Solution found in %d iterations\n', n)
+        else
+            fprintf('>> maximum number of iterations reached, ')
+            fprintf('try again with a narrower interval\n')
+        end
+    end
+
+
 end
-
-
-if ( n ~= MAX_ITER )
-    fprintf('>> Solution found in %d iterations\n', n)
-else
-    fprintf('>> maximum number of iterations reached, ')
-    fprintf('try again with a narrower interval\n')
-end
-
-return
 
 
 % TODO:

--- a/nonlinear-equation-solvers/matlab/bisect.m
+++ b/nonlinear-equation-solvers/matlab/bisect.m
@@ -35,7 +35,7 @@ function x = bisect(a, b, f, opt)
     % output:
     % x            approximate value of the root if successful.
 
-
+    name = 'Bisection';
     % sets default values for the tolerance and max number of iterations
     TOL      = 1.0e-8;
     MAX_ITER = 100;
@@ -87,7 +87,8 @@ function x = bisect(a, b, f, opt)
         % Synopsis: Complains if there's no root in the given interval.
         if ( f(a) * f(b) > 0 )
             errID  = 'NonlinearSolver:BracketingException';
-            errMSG = 'No roots exists in the given interval [a, b]';
+            errMSG = 'No root exists in the given interval [a, b]';
+            errMSG = [name, ' Method: ', errMSG];
             except = MException(errID, errMSG);
             throw(except);
         end
@@ -97,6 +98,7 @@ function x = bisect(a, b, f, opt)
     function report
         % Synopsis: Reports to the user if the method has been successful.
         if ( n ~= MAX_ITER )
+            fprintf('%s Method:\n', name)
             fprintf('>> Solution found in %d iterations\n', n)
         else
             fprintf('>> maximum number of iterations reached, ')

--- a/nonlinear-equation-solvers/matlab/regfal.m
+++ b/nonlinear-equation-solvers/matlab/regfal.m
@@ -25,7 +25,7 @@ function x = regfal(a, b, f, opt)
     % Regula Falsi Method. Finds the root of the function f(x) enclosed by
     % the interval [a, b].
 
-
+    name = 'Regula Falsi';
     % sets default values for the tolerance and maximum number of iterations
     TOL      = 1.0e-8;
     MAX_ITER = 100;
@@ -76,7 +76,8 @@ function x = regfal(a, b, f, opt)
         % Synopsis: Complains if there's no root in the given interval.
         if ( f(a) * f(b) > 0 )
             errID  = 'NonlinearSolver:BracketingException';
-            errMSG = 'No roots exists in the given interval [a, b]';
+            errMSG = 'No root exists in the given interval [a, b]';
+            errMSG = [name, ' Method: ', errMSG];
             except = MException(errID, errMSG);
             throw(except);
         end
@@ -86,6 +87,7 @@ function x = regfal(a, b, f, opt)
     function report
         % Synopsis: Reports to the user if the method has been successful.
         if ( n ~= MAX_ITER )
+            fprintf('%s Method:\n', name)
             fprintf('>> Solution found in %d iterations\n', n)
         else
             fprintf('>> maximum number of iterations reached, ')

--- a/nonlinear-equation-solvers/matlab/regfal.m
+++ b/nonlinear-equation-solvers/matlab/regfal.m
@@ -21,68 +21,81 @@
 
 
 function x = regfal(a, b, f, opt)
-%    Synopsis:
-%    Regula Falsi Method. Finds the root of the function f(x) enclosed by
-%    the interval [a, b].
-%
-%    inputs:
-%    a            lower bound
-%    b            upper bound
-%    f            nonlinear function, f(x)
-%
-%    output:
-%    x            approximate value of the root if successful.
+    % Synopsis:
+    % Regula Falsi Method. Finds the root of the function f(x) enclosed by
+    % the interval [a, b].
 
 
-% sets default values for the tolerance and maximum number of iterations
-TOL      = 1.0e-8;
-MAX_ITER = 100;
+    % sets default values for the tolerance and maximum number of iterations
+    TOL      = 1.0e-8;
+    MAX_ITER = 100;
 
-if ( exist('opt', 'var') )
-    % uses configuration struct if passed
-    TOL      = opt.tol;
-    MAX_ITER = opt.max_iter;
-end
+    optset
+    check_bounds
+    check_bracket
 
-if (a > b)
-    % bounds check
-    up = a;
-    a  = b;
-    b  = up;
-end
+    n = 1;
+    x = ( a * f(b) - b * f(a) ) / ( f(b) - f(a) );
+    while ( n ~= MAX_ITER && abs( f(x) ) > TOL )
 
+        if ( f(a) * f(x) < 0 )
+            b = x;
+        else
+            a = x;
+        end
 
-if ( f(a) * f(b) > 0 )
-    % complains if there's no root in the given interval    
-    errID  = 'NonlinearSolver:BracketingException';
-    errMSG = 'No roots exists in the given interval [a, b]';
-    except = MException(errID, errMSG);
-    throw(except);
-    return
-end
-
-
-n = 1;
-x = ( a * f(b) - b * f(a) ) / ( f(b) - f(a) );
-while ( n ~= MAX_ITER && abs( f(x) ) > TOL )
-
-    % updates the bracketing interval
-    if ( f(a) * f(x) < 0 )
-        b = x;
-    else
-        a = x;
+        x = ( a * f(b) - b * f(a) ) / ( f(b) - f(a) );
+        n = n + 1;
     end
 
-    x = ( a * f(b) - b * f(a) ) / ( f(b) - f(a) );
-    n = n + 1;
+    report
+    return
+
+
+    %```nested functions:```%
+    function optset
+        % Synopsis: Uses configuration struct if provided by user.
+        if ( exist('opt', 'var') )
+            TOL      = opt.tol;
+            MAX_ITER = opt.max_iter;
+        end
+    end
+
+
+    function check_bounds
+        % Synopsis: Ensures the lower bound is less than the upper bound.
+        if (a > b)
+            up = a;
+            a  = b;
+            b  = up;
+        end
+    end
+
+
+    function check_bracket
+        % Synopsis: Complains if there's no root in the given interval.
+        if ( f(a) * f(b) > 0 )
+            errID  = 'NonlinearSolver:BracketingException';
+            errMSG = 'No roots exists in the given interval [a, b]';
+            except = MException(errID, errMSG);
+            throw(except);
+        end
+    end
+
+
+    function report
+        % Synopsis: Reports to the user if the method has been successful.
+        if ( n ~= MAX_ITER )
+            fprintf('>> Solution found in %d iterations\n', n)
+        else
+            fprintf('>> maximum number of iterations reached, ')
+            fprintf('try again with a narrower interval\n')
+        end
+    end
+
+
 end
 
 
-if ( n ~= MAX_ITER )
-    fprintf('>> Solution found in %d iterations\n', n)
-else
-    fprintf('>> maximum number of iterations reached, ')
-    fprintf('try again with a narrower interval\n')
-end
-
-return
+% TODO:
+% [x] Add code for user-defined tolerance and maximum number of iterations.

--- a/nonlinear-equation-solvers/matlab/shifter.m
+++ b/nonlinear-equation-solvers/matlab/shifter.m
@@ -21,82 +21,91 @@
 
 
 function x = shifter(a, b, f, opt)
-%    Synopsis:
-%    Shifter Method. Finds the root of the function f(x) enclosed by
-%    the interval [a, b].
-%
-%    inputs:
-%    a            lower bound
-%    b            upper bound
-%    f            nonlinear function, f(x)
-%
-%    output:
-%    x            approximate value of the root if successful.
+    % Synopsis:
+    % Shifter Method. Finds the root of the function f(x) enclosed by
+    % the interval [a, b].
 
+    TOL      = 1.0e-8;
+    MAX_ITER = 100;
 
-% sets default values for the tolerance and maximum number of iterations
-TOL      = 1.0e-8;
-MAX_ITER = 100;
+    optset
+    check_bounds
+    check_bracket
 
-if ( exist('opt', 'var') )
-    % uses configuration struct if passed
-    TOL      = opt.tol;
-    MAX_ITER = opt.max_iter;
-end
-
-if (a > b)
-    % bounds check
-    up = a;
-    a  = b;
-    b  = up;
-end
-
-
-if ( f(a) * f(b) > 0 )
-    % complains if there's no root in the given interval    
-    errID  = 'NonlinearSolver:BracketingException';
-    errMSG = 'No roots exists in the given interval [a, b]';
-    except = MException(errID, errMSG);
-    throw(except);
-    return
-end
-
-
-n = 1;
-% shifts towards the step (presumably) closest to the root
-x1 = 0.5 * (a + b);
-x2 = ( a * f(b) - b * f(a) ) / ( f(b) - f(a) );
-if ( abs(f(x1)) < abs(f(x2)) )
-    x = x1;
-else
-    x = x2;
-end
-
-while ( n ~= MAX_ITER && abs( f(x) ) > TOL )
+    n = 1;
+    shift
+    while ( n ~= MAX_ITER && abs( f(x) ) > TOL )
 
     % updates the bracketing interval
-    if ( f(a) * f(x) < 0 )
-        b = x;
-    else
-        a = x;
+        if ( f(a) * f(x) < 0 )
+            b = x;
+        else
+            a = x;
+        end
+
+	shift
+        n = n + 1;
     end
 
-    x1 = 0.5 * (a + b);
-    x2 = ( a * f(b) - b * f(a) ) / ( f(b) - f(a) );
-    if ( abs(f(x1)) < abs(f(x2)) )
-        x = x1;
-    else
-        x = x2;
+    report
+    return
+
+
+    %```nested functions:```%
+    function shift
+        % Synopsis: Shifts to the step (presumably) closest to the root.
+        x1 = 0.5 * (a + b);
+        x2 = ( a * f(b) - b * f(a) ) / ( f(b) - f(a) );
+        if ( abs(f(x1)) < abs(f(x2)) )
+            x = x1;
+        else
+            x = x2;
+        end
     end
-    n = n + 1;
+
+    function optset
+        % Synopsis: Uses configuration struct if provided by user.
+        if ( exist('opt', 'var') )
+            TOL      = opt.tol;
+            MAX_ITER = opt.max_iter;
+        end
+    end
+
+
+    function check_bounds
+        % Synopsis: Ensures the lower bound is less than the upper bound.
+        if (a > b)
+            up = a;
+            a  = b;
+            b  = up;
+        end
+    end
+
+
+    function check_bracket
+        % Synopsis: Complains if there's no root in the given interval.
+        if ( f(a) * f(b) > 0 )
+            errID  = 'NonlinearSolver:BracketingException';
+            errMSG = 'No roots exists in the given interval [a, b]';
+            except = MException(errID, errMSG);
+            throw(except);
+        end
+    end
+
+
+    function report
+        % Synopsis: Reports to the user if the method has been successful.
+        if ( n ~= MAX_ITER )
+            fprintf('>> Solution found in %d iterations\n', n)
+        else
+            fprintf('>> maximum number of iterations reached, ')
+            fprintf('try again with a narrower interval\n')
+        end
+    end
+
+
 end
 
 
-if ( n ~= MAX_ITER )
-    fprintf('>> Solution found in %d iterations\n', n)
-else
-    fprintf('>> maximum number of iterations reached, ')
-    fprintf('try again with a narrower interval\n')
-end
-
-return
+% TODO:
+% [x] Add code for user-defined tolerance and maximum number of iterations.

--- a/nonlinear-equation-solvers/matlab/shifter.m
+++ b/nonlinear-equation-solvers/matlab/shifter.m
@@ -25,6 +25,7 @@ function x = shifter(a, b, f, opt)
     % Shifter Method. Finds the root of the function f(x) enclosed by
     % the interval [a, b].
 
+    name = 'Shifter';
     TOL      = 1.0e-8;
     MAX_ITER = 100;
 
@@ -86,7 +87,8 @@ function x = shifter(a, b, f, opt)
         % Synopsis: Complains if there's no root in the given interval.
         if ( f(a) * f(b) > 0 )
             errID  = 'NonlinearSolver:BracketingException';
-            errMSG = 'No roots exists in the given interval [a, b]';
+            errMSG = 'No root exists in the given interval [a, b]';
+            errMSG = [name, ' Method: ', errMSG];
             except = MException(errID, errMSG);
             throw(except);
         end
@@ -96,6 +98,7 @@ function x = shifter(a, b, f, opt)
     function report
         % Synopsis: Reports to the user if the method has been successful.
         if ( n ~= MAX_ITER )
+            fprintf('%s Method:\n', name)
             fprintf('>> Solution found in %d iterations\n', n)
         else
             fprintf('>> maximum number of iterations reached, ')

--- a/nonlinear-equation-solvers/matlab/test.m
+++ b/nonlinear-equation-solvers/matlab/test.m
@@ -39,9 +39,9 @@ f = @(x) 1.0 / sqrt(x) + 2.0 * log10(0.024651/3.7 + ...
 % solves for the root of f(x) numerically
 %[ configuration struct (optional) ]%
 opt = struct('tol', 1.0e-12, 'max_iter', 256);
-x = bisect(a, b, f, opt)	% Bisection
-x = regfal(a, b, f, opt)	% Regula Falsi (or False Position)
-x = shifter(a, b, f, opt)	% Hybrid
+x = bisect (a, b, f, opt)	% Bisection
+x = regfal (a, b, f, opt)	% Regula Falsi (or False Position)
+x = shifter(a, b, f, opt)	% Shifter Method
 
 
 % tests throwing exceptions (interval [a, b] does not contain a root)

--- a/nonlinear-equation-solvers/python/nlsolvers.py
+++ b/nonlinear-equation-solvers/python/nlsolvers.py
@@ -27,8 +27,10 @@ References:
 
 from numpy import abs
 
+
 # sets default values for the tolerance and maximum number of iterations
 TOL, MAX_ITER = (1.0e-8, 100)
+
 
 def check_bounds(bounds):
     """ Synopsis: Fixes bounds if supplied in wrong order. """
@@ -116,5 +118,5 @@ def regfal(bounds, f):
 """
 TODO:
     [ ] use user-supplied values for the tolerance and maximum iterations.
-    [ ] raise an exception when the bracketing interval contains no root.
+    [x] raise an exception when the bracketing interval contains no root.
 """

--- a/nonlinear-equation-solvers/python/nlsolvers.py
+++ b/nonlinear-equation-solvers/python/nlsolvers.py
@@ -60,9 +60,10 @@ def report(it, name):
         print(name + " Method:")
         print(f"solution found in {it} iterations")
     else:
-        print(f"method failed to find the root you may try " + 
+        print(f"method failed to find the root you may try " +
               f"a narrower interval")
     return
+
 
 def optset(**kwargs):
     """
@@ -95,13 +96,13 @@ def bisect(bounds, f, **kwargs):
 
     n, x = (1, (a + b) / 2)
     while ( n != max_iter and abs( f(x) ) > tol ):
-        
+
         # updates bracketing interval [a, b]
         if f(a) * f(x) < 0:
             b = x
         else:
             a = x
-            
+
         x = 0.5 * (a + b)
         n += 1
 
@@ -123,12 +124,12 @@ def regfal(bounds, f, **kwargs):
 
     n, x = ( 1, ( lb * f(ub) - ub * f(lb) ) / ( f(ub) - f(lb) ) )
     while ( n != max_iter and abs( f(x) ) > tol ):
-        
+
         if f(lb) * f(x) < 0:
             ub = x
         else:
             lb = x
-            
+
         x = ( lb * f(ub) - ub * f(lb) ) / ( f(ub) - f(lb) )
         n += 1
 
@@ -136,6 +137,48 @@ def regfal(bounds, f, **kwargs):
     report(n, name)
     return x
 
+
+def shift(lb, ub, f):
+    """ Synopsis: Returns the approximate closest to the root. """
+
+    x1 = 0.5 * (lb + ub)
+    x2 = ( lb * f(ub) - ub * f(lb) ) / ( f(ub) - f(lb) )
+
+    if ( abs(f(x1)) < abs(f(x2)) ):
+        x = x1
+    else:
+        x = x2
+
+    return x
+
+
+def shifter(bounds, f, **kwargs):
+    """ Synopsis:
+    Shifts towards the 'best' approximate of the root of f(x).
+    """
+
+    optional = kwargs.get('opts', None)
+    (tol, max_iter) = optset(opts = optional)
+
+    name = "Shifter"
+    check_bracket(name, bounds, f)
+    lb, ub = check_bounds(bounds)
+
+
+    n, x = ( 1, shift(lb, ub, f) )
+    while ( n != max_iter and abs( f(x) ) > tol ):
+
+        if f(lb) * f(x) < 0:
+            ub = x
+        else:
+            lb = x
+
+        x = shift(lb, ub, f)
+        n += 1
+
+
+    report(n, name)
+    return x
 
 
 

--- a/nonlinear-equation-solvers/python/nlsolvers.py
+++ b/nonlinear-equation-solvers/python/nlsolvers.py
@@ -31,6 +31,7 @@ from numpy import abs
 # sets default values for the tolerance and maximum number of iterations
 TOL, MAX_ITER = (1.0e-8, 100)
 
+nls_opts = {'tol': TOL, 'max_iter': MAX_ITER}
 
 def check_bounds(bounds):
     """ Synopsis: Fixes bounds if supplied in wrong order. """
@@ -63,9 +64,29 @@ def report(it, name):
               f"a narrower interval")
     return
 
+def optset(**kwargs):
+    """
+    Synopsis:
+    Uses the tolerance and maximum number of iterations options provided
+    by the user if any.
+    """
+    opts = kwargs.get('opts', None)
 
-def bisect(bounds, f):
+    if (opts == None):
+        tol      = TOL
+        max_iter = MAX_ITER
+    else:
+        tol = opts['tol']
+        max_iter = opts['max_iter']
+
+    return (tol, max_iter)
+
+
+def bisect(bounds, f, **kwargs):
     """ Synopsis: Possible implementation of the Bisection method. """
+
+    optional = kwargs.get('opts', None)
+    (tol, max_iter) = optset(opts = optional)
 
     name = "Bisection"
     check_bracket(name, bounds, f)
@@ -73,7 +94,7 @@ def bisect(bounds, f):
 
 
     n, x = (1, (a + b) / 2)
-    while ( n != MAX_ITER and abs( f(x) ) > TOL ):
+    while ( n != max_iter and abs( f(x) ) > tol ):
         
         # updates bracketing interval [a, b]
         if f(a) * f(x) < 0:
@@ -89,8 +110,11 @@ def bisect(bounds, f):
     return x
 
 
-def regfal(bounds, f):
+def regfal(bounds, f, **kwargs):
     """ Synopsis: Possible implementation of the Regula Falsi method. """
+
+    optional = kwargs.get('opts', None)
+    (tol, max_iter) = optset(opts = optional)
 
     name = "Regula Falsi"
     check_bracket(name, bounds, f)
@@ -98,7 +122,7 @@ def regfal(bounds, f):
 
 
     n, x = ( 1, ( lb * f(ub) - ub * f(lb) ) / ( f(ub) - f(lb) ) )
-    while ( n != MAX_ITER and abs( f(x) ) > TOL ):
+    while ( n != max_iter and abs( f(x) ) > tol ):
         
         if f(lb) * f(x) < 0:
             ub = x
@@ -117,6 +141,6 @@ def regfal(bounds, f):
 
 """
 TODO:
-    [ ] use user-supplied values for the tolerance and maximum iterations.
+    [x] use user-supplied values for the tolerance and maximum iterations.
     [x] raise an exception when the bracketing interval contains no root.
 """

--- a/nonlinear-equation-solvers/python/nlsolvers.py
+++ b/nonlinear-equation-solvers/python/nlsolvers.py
@@ -30,57 +30,8 @@ from numpy import abs
 
 # sets default values for the tolerance and maximum number of iterations
 TOL, MAX_ITER = (1.0e-8, 100)
-
+# defines options for nonlinear solvers
 nls_opts = {'tol': TOL, 'max_iter': MAX_ITER}
-
-def check_bounds(bounds):
-    """ Synopsis: Fixes bounds if supplied in wrong order. """
-
-    lb, ub = bounds # unpacks lower and upper bounds, respectively
-
-    if (lb > ub):
-        up = lb
-        lb, ub = (ub, up)
-
-    return (lb, ub)
-
-
-def check_bracket(name, bounds, f):
-    """ Synopsis: Complains if there's no root in the given interval. """
-    lb, ub = bounds
-    errMSG = name + ": " + f"No root exist in given interval [{lb}, {ub}]"
-    if ( f(lb) * f(ub) > 0. ):
-        raise RuntimeError(errMSG)
-    return
-
-
-def report(it, name):
-    """ Synopsis: Reports if the method has been successful. """
-    if (it != MAX_ITER):
-        print(name + " Method:")
-        print(f"solution found in {it} iterations")
-    else:
-        print(f"method failed to find the root you may try " +
-              f"a narrower interval")
-    return
-
-
-def optset(**kwargs):
-    """
-    Synopsis:
-    Uses the tolerance and maximum number of iterations options provided
-    by the user if any.
-    """
-    opts = kwargs.get('opts', None)
-
-    if (opts == None):
-        tol      = TOL
-        max_iter = MAX_ITER
-    else:
-        tol = opts['tol']
-        max_iter = opts['max_iter']
-
-    return (tol, max_iter)
 
 
 def bisect(bounds, f, **kwargs):
@@ -138,20 +89,6 @@ def regfal(bounds, f, **kwargs):
     return x
 
 
-def shift(lb, ub, f):
-    """ Synopsis: Returns the approximate closest to the root. """
-
-    x1 = 0.5 * (lb + ub)
-    x2 = ( lb * f(ub) - ub * f(lb) ) / ( f(ub) - f(lb) )
-
-    if ( abs(f(x1)) < abs(f(x2)) ):
-        x = x1
-    else:
-        x = x2
-
-    return x
-
-
 def shifter(bounds, f, **kwargs):
     """ Synopsis:
     Shifts towards the 'best' approximate of the root of f(x).
@@ -179,6 +116,71 @@ def shifter(bounds, f, **kwargs):
 
     report(n, name)
     return x
+
+
+def shift(lb, ub, f):
+    """ Synopsis: Returns the approximate closest to the root. """
+
+    x1 = 0.5 * (lb + ub)
+    x2 = ( lb * f(ub) - ub * f(lb) ) / ( f(ub) - f(lb) )
+
+    if ( abs(f(x1)) < abs(f(x2)) ):
+        x = x1
+    else:
+        x = x2
+
+    return x
+
+
+def optset(**kwargs):
+    """
+    Synopsis:
+    Uses the tolerance and maximum number of iterations options provided
+    by the user if any.
+    """
+    opts = kwargs.get('opts', None)
+
+    if (opts == None):
+        tol      = TOL
+        max_iter = MAX_ITER
+    else:
+        tol = opts['tol']
+        max_iter = opts['max_iter']
+
+    return (tol, max_iter)
+
+
+def report(it, name):
+    """ Synopsis: Reports if the method has been successful. """
+    if (it != MAX_ITER):
+        print(name + " Method:")
+        print(f"solution found in {it} iterations")
+    else:
+        print(f"method failed to find the root you may try " +
+              f"a narrower interval")
+    return
+
+
+def check_bracket(name, bounds, f):
+    """ Synopsis: Complains if there's no root in the given interval. """
+    lb, ub = bounds
+    errMSG = name + ": " + f"No root exist in given interval [{lb}, {ub}]"
+    if ( f(lb) * f(ub) > 0. ):
+        raise RuntimeError(errMSG)
+    return
+
+
+def check_bounds(bounds):
+    """ Synopsis: Fixes bounds if supplied in wrong order. """
+
+    lb, ub = bounds # unpacks lower and upper bounds, respectively
+
+    if (lb > ub):
+        up = lb
+        lb, ub = (ub, up)
+
+    return (lb, ub)
+
 
 
 

--- a/nonlinear-equation-solvers/python/nlsolvers.py
+++ b/nonlinear-equation-solvers/python/nlsolvers.py
@@ -42,17 +42,19 @@ def check_bounds(bounds):
     return (lb, ub)
 
 
-def check_bracket(bounds, f):
+def check_bracket(name, bounds, f):
     """ Synopsis: Complains if there's no root in the given interval. """
     lb, ub = bounds
+    errMSG = name + ": " + f"No root exist in given interval [{lb}, {ub}]"
     if ( f(lb) * f(ub) > 0. ):
-        raise RuntimeError(f"No root exist in given interval [{lb}, {ub}]")
+        raise RuntimeError(errMSG)
     return
 
 
-def report(it):
+def report(it, name):
     """ Synopsis: Reports if the method has been successful. """
     if (it != MAX_ITER):
+        print(name + " Method:")
         print(f"solution found in {it} iterations")
     else:
         print(f"method failed to find the root you may try " + 
@@ -63,7 +65,8 @@ def report(it):
 def bisect(bounds, f):
     """ Synopsis: Possible implementation of the Bisection method. """
 
-    check_bracket(bounds, f)
+    name = "Bisection"
+    check_bracket(name, bounds, f)
     a, b = check_bounds(bounds)
 
 
@@ -80,14 +83,15 @@ def bisect(bounds, f):
         n += 1
 
 
-    report(n)
+    report(n, name)
     return x
 
 
 def regfal(bounds, f):
     """ Synopsis: Possible implementation of the Regula Falsi method. """
 
-    check_bracket(bounds, f)
+    name = "Regula Falsi"
+    check_bracket(name, bounds, f)
     lb, ub = check_bounds(bounds)
 
 
@@ -103,7 +107,7 @@ def regfal(bounds, f):
         n += 1
 
 
-    report(n)
+    report(n, name)
     return x
 
 

--- a/nonlinear-equation-solvers/python/test_nlsolvers.py
+++ b/nonlinear-equation-solvers/python/test_nlsolvers.py
@@ -26,8 +26,13 @@ References:
 
 from numpy import sqrt
 from numpy import log10
-from nlsolvers import bisect, regfal
+from nlsolvers import bisect, regfal, nls_opts
 
+# copies nonlinear solver options into a dictionary
+options = nls_opts
+# overrides defaults
+options['tol']      = 1.0e-12
+options['max_iter'] = 256
 
 bounds = (2.0e-2, 7.0e-2)   # bracketing interval [a, b]
 
@@ -39,9 +44,8 @@ f = lambda x: (
 
 
 """ solves for the enclosed root with the specified method """
-x = bisect(bounds, f)   # Bisection
-x = regfal(bounds, f)   # Regula Falsi
-
+x = bisect(bounds, f, opts = options)   # Bisection
+x = regfal(bounds, f, opts = options)   # Regula Falsi
 
 # tests for a non-enclosing interval
 # bounds = (6.0e-2, 7.0e-2)

--- a/nonlinear-equation-solvers/python/test_nlsolvers.py
+++ b/nonlinear-equation-solvers/python/test_nlsolvers.py
@@ -26,7 +26,7 @@ References:
 
 from numpy import sqrt
 from numpy import log10
-from nlsolvers import bisect, regfal, nls_opts
+from nlsolvers import bisect, regfal, shifter, nls_opts
 
 # copies nonlinear solver options into a dictionary
 options = nls_opts
@@ -34,7 +34,7 @@ options = nls_opts
 options['tol']      = 1.0e-12
 options['max_iter'] = 256
 
-bounds = (2.0e-2, 7.0e-2)   # bracketing interval [a, b]
+bounds = (1.0e-2, 9.0e-2)   # bracketing interval [a, b]
 
 
 """ nonlinear function f(x) """
@@ -44,10 +44,13 @@ f = lambda x: (
 
 
 """ solves for the enclosed root with the specified method """
-x = bisect(bounds, f, opts = options)   # Bisection
-x = regfal(bounds, f, opts = options)   # Regula Falsi
+x = bisect (bounds, f, opts = options)   # Bisection
+x = regfal (bounds, f, opts = options)   # Regula Falsi
+x = shifter(bounds, f, opts = options)   # Shifter Method
 
-# tests for a non-enclosing interval
+
+""" tests for a non-enclosing interval """
 # bounds = (6.0e-2, 7.0e-2)
-# x = bisect(bounds, f) passed
-# x = regfal(bounds, f) passed
+# x = bisect (bounds, f) passed
+# x = regfal (bounds, f) passed
+# x = shifter(bounds, f) passed


### PR DESCRIPTION
Implements the shifter method and the configuration struct for nonlinear solvers in Python and FORTRAN.

Partitions the code into smaller functions or subroutines and improves the readability of MATLAB source files by using python-like indentation.

These changes make the numerical methods display their names when producing output and errors (or exceptions).