### PR TITLE
fixes report BUG and aborts if method does not converge

### DIFF
--- a/nonlinear-equation-solvers/clang/nlsolvers.c
+++ b/nonlinear-equation-solvers/clang/nlsolvers.c
@@ -71,7 +71,7 @@ double bisect_base ( double lb, double ub, double f(const double),
         do fm = bisector (&lb, &ub, &xm, f) ;
         while (++n != max_iter && fm > tol) ;
 
-	report (n, nm) ;
+	report (max_iter, n, nm) ;
 	return xm ;
 
 }
@@ -91,7 +91,7 @@ double regfal_base ( double lb, double ub, double f(const double),
         do fn = interp (&lb, &ub, &xn, f) ;
         while (++n != max_iter && fn > tol) ;
 
-	report (n, nm) ;
+	report (max_iter, n, nm) ;
 	return xn ;
 
 }
@@ -111,20 +111,21 @@ double shifter_base ( double lb, double ub, double f(const double),
         do fn = shift (&lb, &ub, &xn, f) ;
         while (++n != max_iter && fn > tol) ;
 
-	report (n, nm) ;
+	report (max_iter, n, nm) ;
 	return xn ;
 
 }
 
 
-void report (const int n, char nm[]) {
+void report (const int max_iter, const int n, char nm[]) {
 	// reports if the method has been successful
-	if (n != MAX_ITER) {
+	if (n != max_iter) {
 		printf("%s Method:\n", nm) ;
 		printf("solution found in %d iterations\n", n) ;
 	} else {
-		printf("method failed to find the root, ") ; 
-		printf("you may try a narrower interval\n") ;
+		fprintf(stderr, "%s method needs additional ", nm) ;
+		fprintf(stderr, "iterations for convergence\n") ;
+		exit(EXIT_FAILURE) ;
 	}
 }
 
@@ -232,7 +233,7 @@ void check_bounds ( double *lb, double *ub ) {
  * [x] Implement guards against "empty" ranges (lower > upper bound)
  * [x] Implement guards against applying the method on an interval
  *     that does not enclose a root.
- * [ ] Define default values for the tolerance and maximum number of
+ * [x] Define default values for the tolerance and maximum number of
  *     iterations. The user may wish to override these parameters so these
  *     must be included in the argument lists. Use the constants as default
  *     values for these parameters. Consider implementing a configuration

--- a/nonlinear-equation-solvers/clang/nlsolvers.c
+++ b/nonlinear-equation-solvers/clang/nlsolvers.c
@@ -30,35 +30,38 @@
 #include "nlsolvers.h"
 
 // implementations
-double bisect_varg ( double lb, double ub, double f(const double),
-		     opt_args args )
+double bisect_varg ( double lb, double ub, double f(double),
+                     opt_args args )
 {	// shadow function which handles initialization of optional args
 	double tol = args.opts.tol? args.opts.tol: TOL ;
 	int max_iter = args.opts.max_iter? args.opts.max_iter: MAX_ITER ;
-	return bisect_base (lb, ub, f, tol, max_iter) ;
+	int verbose  = args.opts.verbose ? args.opts.verbose : VERBOSE ;
+	return bisect_base (lb, ub, f, tol, max_iter, verbose) ;
 }
 
 
-double regfal_varg ( double lb, double ub, double f(const double),
-		     opt_args args )
+double regfal_varg ( double lb, double ub, double f(double),
+                     opt_args args )
 {	// shadow function
 	double tol = args.opts.tol? args.opts.tol: TOL ;
 	int max_iter = args.opts.max_iter? args.opts.max_iter: MAX_ITER ;
-	return regfal_base (lb, ub, f, tol, max_iter) ;
+	int verbose  = args.opts.verbose ? args.opts.verbose : VERBOSE ;
+	return regfal_base (lb, ub, f, tol, max_iter, verbose) ;
 }
 
 
-double shifter_varg ( double lb, double ub, double f(const double),
-		      opt_args args )
+double shifter_varg ( double lb, double ub, double f(double),
+                      opt_args args )
 {	// shadow function
 	double tol = args.opts.tol? args.opts.tol: TOL ;
 	int max_iter = args.opts.max_iter? args.opts.max_iter: MAX_ITER ;
-	return shifter_base (lb, ub, f, tol, max_iter) ;
+	int verbose  = args.opts.verbose ? args.opts.verbose : VERBOSE ;
+	return shifter_base (lb, ub, f, tol, max_iter, verbose) ;
 }
 
 
-double bisect_base ( double lb, double ub, double f(const double),
-		     double tol, int max_iter )
+double bisect_base ( double lb, double ub, double f(double),
+                     double tol, int max_iter, bool verbose )
 {	// Bisection Method
 
 	char nm[] = "Bisection" ;
@@ -71,14 +74,14 @@ double bisect_base ( double lb, double ub, double f(const double),
         do fm = bisector (&lb, &ub, &xm, f) ;
         while (++n != max_iter && fm > tol) ;
 
-	report (max_iter, n, nm) ;
+	report (max_iter, n, nm, verbose) ;
 	return xm ;
 
 }
 
 
-double regfal_base ( double lb, double ub, double f(const double),
-	             double tol, int max_iter )
+double regfal_base ( double lb, double ub, double f(double),
+                     double tol, int max_iter, bool verbose )
 {	// Regula Falsi Method
 
 	char nm[] = "Regula-Falsi" ;
@@ -91,14 +94,14 @@ double regfal_base ( double lb, double ub, double f(const double),
         do fn = interp (&lb, &ub, &xn, f) ;
         while (++n != max_iter && fn > tol) ;
 
-	report (max_iter, n, nm) ;
+	report (max_iter, n, nm, verbose) ;
 	return xn ;
 
 }
 
 
-double shifter_base ( double lb, double ub, double f(const double),
-	         double tol, int max_iter )
+double shifter_base ( double lb, double ub, double f(double),
+                      double tol, int max_iter, bool verbose )
 {	// Shifter Method
 
 	char nm[] = "Shifter" ;
@@ -111,17 +114,19 @@ double shifter_base ( double lb, double ub, double f(const double),
         do fn = shift (&lb, &ub, &xn, f) ;
         while (++n != max_iter && fn > tol) ;
 
-	report (max_iter, n, nm) ;
+	report (max_iter, n, nm, verbose) ;
 	return xn ;
 
 }
 
 
-void report (const int max_iter, const int n, char nm[]) {
+void report (int max_iter, int n, char nm[], bool verbose) {
 	// reports if the method has been successful
 	if (n != max_iter) {
-		printf("%s Method:\n", nm) ;
-		printf("solution found in %d iterations\n", n) ;
+		if (verbose) {
+			printf("%s Method:\n", nm) ;
+			printf("solution found in %d iterations\n", n) ;
+		}
 	} else {
 		fprintf(stderr, "%s method needs additional ", nm) ;
 		fprintf(stderr, "iterations for convergence\n") ;
@@ -131,7 +136,7 @@ void report (const int max_iter, const int n, char nm[]) {
 
 
 double bisector ( double *lb, double *ub, double *xm, 
-		  double f(const double) )
+		  double f(double) )
 {
 
 /*
@@ -167,7 +172,7 @@ double bisector ( double *lb, double *ub, double *xm,
 
 
 double interp ( double *lb, double *ub, double *xn,
-		double f(const double) )
+		double f(double) )
 {	// like bisector but uses interpolation to approximate the root
         *xn = ( *lb * f(*ub) - *ub * f(*lb) ) / ( f(*ub) - f(*lb) ) ;
 	double fn = f(*xn) ;
@@ -182,7 +187,7 @@ double interp ( double *lb, double *ub, double *xn,
 
 
 double shift ( double *lb, double *ub, double *xn,
-	       double f(const double) )
+	       double f(double) )
 {	// uses hybrid approach to approximate the root
 	double fn ;
 	double xb = 0.5 * (*lb + *ub) ;
@@ -206,7 +211,7 @@ double shift ( double *lb, double *ub, double *xn,
 
 
 void check_bracket ( double lb, double ub,
-		     double f(const double), char nm[] )
+		     double f(double), char nm[] )
 {
 	// complains if there's no root in given interval and aborts
 	if ( f(lb) * f(ub) > 0. ) {

--- a/nonlinear-equation-solvers/clang/nlsolvers.h
+++ b/nonlinear-equation-solvers/clang/nlsolvers.h
@@ -68,7 +68,7 @@ double interp   ( double*, double*, double*, double f(const double) ) ;
 double shift    ( double*, double*, double*, double f(const double) ) ;
 
 // utility functions
-void report        ( const int n, char nm[] ) ;
+void report        ( const int max_iter, const int n, char nm[] ) ;
 void check_bracket ( double, double, double f(const double), char nm[] ) ;
 void check_bounds  ( double*, double* ) ;
 #endif

--- a/nonlinear-equation-solvers/clang/nlsolvers.h
+++ b/nonlinear-equation-solvers/clang/nlsolvers.h
@@ -25,16 +25,19 @@
  *
  */
 
+#include <stdbool.h>
 // Math MACROS
 #define absval(x) ((x < 0.)? -x: x)
 
 // constants (defaults)
 #define MAX_ITER 100
 #define TOL 1.0e-8
+#define VERBOSE false
 
 typedef struct {
 	double tol ;	// tolerance
 	int max_iter ;	// maximum number of iterations
+	bool verbose ;
 } nls_conf ;		// nonlinear-solver configuration struct
 
 typedef struct {
@@ -45,14 +48,14 @@ typedef struct {
 // declarations (prototypes):
 
 // shadow functions (handle initialization of optional arguments)
-double bisect_varg (double, double, double f(const double), opt_args) ;
-double regfal_varg (double, double, double f(const double), opt_args) ;
-double shifter_varg(double, double, double f(const double), opt_args) ;
+double bisect_varg (double, double, double f(double), opt_args) ;
+double regfal_varg (double, double, double f(double), opt_args) ;
+double shifter_varg(double, double, double f(double), opt_args) ;
 
 // base functions (where the respective method is actually implemented)
-double bisect_base (double, double, double f(const double), double, int) ;
-double regfal_base (double, double, double f(const double), double, int) ;
-double shifter_base(double, double, double f(const double), double, int) ;
+double bisect_base (double, double, double f(double), double, int, bool) ;
+double regfal_base (double, double, double f(double), double, int, bool) ;
+double shifter_base(double, double, double f(double), double, int, bool) ;
 
 // wrapper MACROS
 #define bisect(lb, ub, f, ...)\
@@ -63,13 +66,13 @@ double shifter_base(double, double, double f(const double), double, int) ;
 	shifter_varg(lb, ub, f, (opt_args){__VA_ARGS__})
 
 // bracketing approach
-double bisector ( double*, double*, double*, double f(const double) ) ;
-double interp   ( double*, double*, double*, double f(const double) ) ;
-double shift    ( double*, double*, double*, double f(const double) ) ;
+double bisector ( double*, double*, double*, double f(double) ) ;
+double interp   ( double*, double*, double*, double f(double) ) ;
+double shift    ( double*, double*, double*, double f(double) ) ;
 
 // utility functions
-void report        ( const int max_iter, const int n, char nm[] ) ;
-void check_bracket ( double, double, double f(const double), char nm[] ) ;
+void report        ( int, int, char*, bool ) ;
+void check_bracket ( double, double, double f(double), char nm[] ) ;
 void check_bounds  ( double*, double* ) ;
 #endif
 

--- a/nonlinear-equation-solvers/clang/test_bracketing.c
+++ b/nonlinear-equation-solvers/clang/test_bracketing.c
@@ -28,7 +28,7 @@
 #include <stdio.h>
 #include "nlsolvers.h"
 
-double f (const double) ;	/* nonlinear function, f(x) */
+double f (double) ;	/* nonlinear function, f(x) */
 
 int main() {
 	// Solves for the positive root of the nonlinear function f(x)
@@ -60,7 +60,7 @@ int main() {
 }
 
 
-double f (const double x) {
+double f (double x) {
 	// defines the nonlinear function f(x)
 	return ( 1.0 / sqrt(x) + 2.0 * log10(0.024651/3.7 +
 	         2.51/(9655526.5 * sqrt(x) ) ) ) ;

--- a/nonlinear-equation-solvers/cxx/module-nonlinear-solvers.cpp
+++ b/nonlinear-equation-solvers/cxx/module-nonlinear-solvers.cpp
@@ -51,7 +51,7 @@ export namespace nlsolver {
 
 
 // declarations (prototypes)
-void report (const int& n, const std::string& nm) ;
+void report (const int& max_iter, const int& n, const std::string& nm) ;
 void check_bounds ( double& lb, double& ub ) ;
 
 void check_bracket ( const double& lb, const double& ub,
@@ -78,7 +78,7 @@ double nlsolver::bisect ( double lb, double ub,
         do fm = bisector (lb, ub, xm, f) ;
         while (++n != opt.max_iter && fm > opt.tol) ;
 
-	report (n, nm) ;
+	report (opt.max_iter, n, nm) ;
 	return xm ;
 
 }
@@ -98,7 +98,7 @@ double nlsolver::regfal ( double lb, double ub,
         do fn = interp (lb, ub, xn, f) ;
         while (++n != opt.max_iter && fn > opt.tol) ;
 
-	report (n, nm) ;
+	report (opt.max_iter, n, nm) ;
 	return xn ;
 
 }
@@ -118,7 +118,7 @@ double nlsolver::shifter ( double lb, double ub,
         do fn = shift (lb, ub, xn, f) ;
         while (++n != opt.max_iter && fn > opt.tol) ;
 
-	report (n, nm) ;
+	report (opt.max_iter, n, nm) ;
 	return xn ;
 
 }
@@ -147,15 +147,16 @@ void check_bracket ( const double& lb, const double& ub,
 }
 
 
-void report (const int& n, const std::string& nm) {
+void report (const int& max_iter, const int& n, const std::string& nm) {
 	// reports if the method has been successful
-	if (n != MAX_ITER) {
+	if (n != max_iter) {
 		std::cout << nm << " Method:" << std::endl ;
 		std::cout << "solution found in " << n << " "
 			  << "iterations" << std::endl ;
 	} else {
-		std::cout << "method failed to find the root, " 
-		    "you may try a narrower interval" << std::endl ;
+		std::string errMSG = nm + " method requires more "
+			"iterations for convergence" ;
+		throw std::runtime_error (errMSG) ;
 	}
 }
 

--- a/nonlinear-equation-solvers/cxx/module-nonlinear-solvers.cpp
+++ b/nonlinear-equation-solvers/cxx/module-nonlinear-solvers.cpp
@@ -40,10 +40,18 @@ export namespace nlsolver {
 
 	struct config {	// config[uration] struct
 		config(): tol(TOL), max_iter(MAX_ITER), verbose(VERBOSE) {}
-		config(double t): tol(t), max_iter(MAX_ITER),
+		config(double t): tol(t),   max_iter(MAX_ITER),
 	                          verbose(VERBOSE) {}
-		config(double t, int i): tol(t), max_iter(i),
-	                                 verbose(VERBOSE) {}
+		config(int    i): tol(TOL), max_iter(i),
+	                          verbose(VERBOSE) {}
+		config(bool   v): tol(TOL), max_iter(MAX_ITER),
+	                          verbose(v) {}
+		config(double t, int  i): tol(t), max_iter(i),
+	                                  verbose(VERBOSE) {}
+		config(double t, bool v): tol(t), max_iter(MAX_ITER),
+	                                  verbose(v) {}
+		config(int    i, bool v): tol(TOL), max_iter(i),
+	                                  verbose(v) {}
 		config(double t, int i, bool v): tol(t), max_iter(i),
 	                                         verbose(v) {}
 		double tol ;

--- a/nonlinear-equation-solvers/cxx/module-nonlinear-solvers.cpp
+++ b/nonlinear-equation-solvers/cxx/module-nonlinear-solvers.cpp
@@ -34,14 +34,21 @@ export module nonlinear_solvers ;
 // constants
 const int MAX_ITER = 100 ;
 const double TOL = 1.0e-8 ;
+const bool VERBOSE = false ;
 
 export namespace nlsolver {
 
 	struct config {	// config[uration] struct
-		config(): tol(TOL), max_iter(MAX_ITER) {}
-		config(double t, int i): tol(t), max_iter(i) {}
+		config(): tol(TOL), max_iter(MAX_ITER), verbose(VERBOSE) {}
+		config(double t): tol(t), max_iter(MAX_ITER),
+	                          verbose(VERBOSE) {}
+		config(double t, int i): tol(t), max_iter(i),
+	                                 verbose(VERBOSE) {}
+		config(double t, int i, bool v): tol(t), max_iter(i),
+	                                         verbose(v) {}
 		double tol ;
 		int max_iter ;
+		bool verbose ;
 	} ;
 
 	double bisect ( double, double, double f(const double&), config ) ;
@@ -51,7 +58,8 @@ export namespace nlsolver {
 
 
 // declarations (prototypes)
-void report (const int& max_iter, const int& n, const std::string& nm) ;
+void report (const int& n, const std::string& nm,
+             const nlsolver::config& opt) ;
 void check_bounds ( double& lb, double& ub ) ;
 
 void check_bracket ( const double& lb, const double& ub,
@@ -78,7 +86,7 @@ double nlsolver::bisect ( double lb, double ub,
         do fm = bisector (lb, ub, xm, f) ;
         while (++n != opt.max_iter && fm > opt.tol) ;
 
-	report (opt.max_iter, n, nm) ;
+	report (n, nm, opt) ;
 	return xm ;
 
 }
@@ -98,7 +106,7 @@ double nlsolver::regfal ( double lb, double ub,
         do fn = interp (lb, ub, xn, f) ;
         while (++n != opt.max_iter && fn > opt.tol) ;
 
-	report (opt.max_iter, n, nm) ;
+	report (n, nm, opt) ;
 	return xn ;
 
 }
@@ -118,7 +126,7 @@ double nlsolver::shifter ( double lb, double ub,
         do fn = shift (lb, ub, xn, f) ;
         while (++n != opt.max_iter && fn > opt.tol) ;
 
-	report (opt.max_iter, n, nm) ;
+	report (n, nm, opt) ;
 	return xn ;
 
 }
@@ -147,12 +155,16 @@ void check_bracket ( const double& lb, const double& ub,
 }
 
 
-void report (const int& max_iter, const int& n, const std::string& nm) {
+void report (const int& n, const std::string& nm,
+             const nlsolver::config& opt)
+{
 	// reports if the method has been successful
-	if (n != max_iter) {
-		std::cout << nm << " Method:" << std::endl ;
-		std::cout << "solution found in " << n << " "
-			  << "iterations" << std::endl ;
+	if (n != opt.max_iter) {
+		if (opt.verbose) {
+			std::cout << nm << " Method:" << std::endl ;
+			std::cout << "solution found in " << n << " "
+                                  << "iterations" << std::endl ;
+		}
 	} else {
 		std::string errMSG = nm + " method requires more "
 			"iterations for convergence" ;

--- a/nonlinear-equation-solvers/cxx/test-bracketing.cpp
+++ b/nonlinear-equation-solvers/cxx/test-bracketing.cpp
@@ -45,7 +45,8 @@ using nlsolver::shifter ;
 int main() {
 	// Solves for the positive root of the nonlinear function f(x)
 	
-	config opt{1.0e-12, 256} ;	// tolerance and max num iterations
+	// tolerance, maximum number of iterations, and verbosity
+	config opt{1.0e-12, 256, false} ;
 	
 	auto f = [](const double& x) -> double {
 	    return ( 1.0 / sqrt(x) + 2.0 * log10(0.024651/3.7 +

--- a/nonlinear-equation-solvers/fortran/nlsolvers.for
+++ b/nonlinear-equation-solvers/fortran/nlsolvers.for
@@ -75,7 +75,7 @@ module nlsolvers
                 n = n + 1
             end do
 
-            call report (n, nm)
+            call report (maxit, n, nm)
 
             return
         end function
@@ -123,7 +123,7 @@ module nlsolvers
                 n = n + 1
             end do
 
-            call report (n, nm)
+            call report (maxit, n, nm)
 
             return
         end function
@@ -176,7 +176,7 @@ module nlsolvers
                 n = n + 1
             end do
 
-            call report (n, nm)
+            call report (maxit, n, nm)
 
             return
         end function
@@ -210,11 +210,12 @@ module nlsolvers
         end subroutine
 
 
-        subroutine report (n, name)
+        subroutine report (maxit, n, name)
+            integer(kind = int32), intent(in) :: maxit
             integer(kind = int32), intent(in) :: n
             character(len=*), intent(in) :: name
 
-            if (n /= MAX_ITER) then
+            if (n /= maxit) then
                 print *, name // " Method: "
                 print *, "solution found in ", n, " iterations"
             else

--- a/nonlinear-equation-solvers/fortran/nlsolvers.for
+++ b/nonlinear-equation-solvers/fortran/nlsolvers.for
@@ -214,13 +214,14 @@ module nlsolvers
             integer(kind = int32), intent(in) :: maxit
             integer(kind = int32), intent(in) :: n
             character(len=*), intent(in) :: name
+            character(len=*), parameter :: errmsg = &
+                & "method needs more iterations for convergence"
 
             if (n /= maxit) then
                 print *, name // " Method: "
                 print *, "solution found in ", n, " iterations"
             else
-                print *, "maximum number of iterations has been " // &
-                       & "reached, try again with a narrower interval"
+                error stop (name // " " // errmsg)
             end if
 
             return

--- a/nonlinear-equation-solvers/fortran/test_solvers.for
+++ b/nonlinear-equation-solvers/fortran/test_solvers.for
@@ -59,6 +59,7 @@ program tests
     ! sets the tolerance and maximum number of iterations of the solver
     opts % tol      = 1.0e-12_real64
     opts % max_iter = 256
+    opts % verbose  = .false.
 
     ! defines the (root) bracketing interval [lb, ub]
     lb = 1.0e-2_real64

--- a/nonlinear-equation-solvers/matlab/bisect.m
+++ b/nonlinear-equation-solvers/matlab/bisect.m
@@ -101,8 +101,11 @@ function x = bisect(a, b, f, opt)
             fprintf('%s Method:\n', name)
             fprintf('>> Solution found in %d iterations\n', n)
         else
-            fprintf('>> maximum number of iterations reached, ')
-            fprintf('try again with a narrower interval\n')
+            errID  = 'NonlinearSolver:ConvergenceException';
+            errMSG = 'requires additional iterations for convergence';
+            errMSG = [name, ' method ', errMSG];
+            except = MException(errID, errMSG);
+            throw(except);
         end
     end
 

--- a/nonlinear-equation-solvers/matlab/bisect.m
+++ b/nonlinear-equation-solvers/matlab/bisect.m
@@ -39,6 +39,7 @@ function x = bisect(a, b, f, opt)
     % sets default values for the tolerance and max number of iterations
     TOL      = 1.0e-8;
     MAX_ITER = 100;
+    VERBOSE  = 0;
 
     optset
     check_bounds
@@ -67,9 +68,18 @@ function x = bisect(a, b, f, opt)
     function optset
         % Synopsis: Uses configuration struct if provided by user.
         if ( exist('opt', 'var') )
-            TOL      = opt.tol;
-            MAX_ITER = opt.max_iter;
-        end
+            if ( isfield(opt, 'tol') )
+                TOL      = opt.tol;
+            end
+
+            if ( isfield(opt, 'max_iter') )
+                MAX_ITER = opt.max_iter;
+            end
+
+            if ( isfield(opt, 'verbose') )
+                VERBOSE  = opt.verbose;
+            end
+	end
     end
 
 
@@ -98,8 +108,10 @@ function x = bisect(a, b, f, opt)
     function report
         % Synopsis: Reports to the user if the method has been successful.
         if ( n ~= MAX_ITER )
-            fprintf('%s Method:\n', name)
-            fprintf('>> Solution found in %d iterations\n', n)
+	    if (VERBOSE)
+                fprintf('%s Method:\n', name)
+                fprintf('>> Solution found in %d iterations\n', n)
+	    end
         else
             errID  = 'NonlinearSolver:ConvergenceException';
             errMSG = 'requires additional iterations for convergence';

--- a/nonlinear-equation-solvers/matlab/regfal.m
+++ b/nonlinear-equation-solvers/matlab/regfal.m
@@ -29,6 +29,7 @@ function x = regfal(a, b, f, opt)
     % sets default values for the tolerance and maximum number of iterations
     TOL      = 1.0e-8;
     MAX_ITER = 100;
+    VERBOSE  = 0;
 
     optset
     check_bounds
@@ -56,9 +57,18 @@ function x = regfal(a, b, f, opt)
     function optset
         % Synopsis: Uses configuration struct if provided by user.
         if ( exist('opt', 'var') )
-            TOL      = opt.tol;
-            MAX_ITER = opt.max_iter;
-        end
+            if ( isfield(opt, 'tol') )
+                TOL      = opt.tol;
+            end
+
+            if ( isfield(opt, 'max_iter') )
+                MAX_ITER = opt.max_iter;
+            end
+
+            if ( isfield(opt, 'verbose') )
+                VERBOSE  = opt.verbose;
+            end
+	end
     end
 
 
@@ -87,8 +97,10 @@ function x = regfal(a, b, f, opt)
     function report
         % Synopsis: Reports to the user if the method has been successful.
         if ( n ~= MAX_ITER )
-            fprintf('%s Method:\n', name)
-            fprintf('>> Solution found in %d iterations\n', n)
+	    if (VERBOSE)
+                fprintf('%s Method:\n', name)
+                fprintf('>> Solution found in %d iterations\n', n)
+	    end
         else
             errID  = 'NonlinearSolver:ConvergenceException';
             errMSG = 'requires additional iterations for convergence';

--- a/nonlinear-equation-solvers/matlab/regfal.m
+++ b/nonlinear-equation-solvers/matlab/regfal.m
@@ -90,8 +90,11 @@ function x = regfal(a, b, f, opt)
             fprintf('%s Method:\n', name)
             fprintf('>> Solution found in %d iterations\n', n)
         else
-            fprintf('>> maximum number of iterations reached, ')
-            fprintf('try again with a narrower interval\n')
+            errID  = 'NonlinearSolver:ConvergenceException';
+            errMSG = 'requires additional iterations for convergence';
+            errMSG = [name, ' method ', errMSG];
+            except = MException(errID, errMSG);
+            throw(except);
         end
     end
 

--- a/nonlinear-equation-solvers/matlab/shifter.m
+++ b/nonlinear-equation-solvers/matlab/shifter.m
@@ -28,6 +28,7 @@ function x = shifter(a, b, f, opt)
     name = 'Shifter';
     TOL      = 1.0e-8;
     MAX_ITER = 100;
+    VERBOSE  = 0;
 
     optset
     check_bounds
@@ -67,8 +68,17 @@ function x = shifter(a, b, f, opt)
     function optset
         % Synopsis: Uses configuration struct if provided by user.
         if ( exist('opt', 'var') )
-            TOL      = opt.tol;
-            MAX_ITER = opt.max_iter;
+	    if ( isfield(opt, 'tol') )
+                TOL      = opt.tol;
+	    end
+
+	    if ( isfield(opt, 'max_iter') )
+                MAX_ITER = opt.max_iter;
+	    end
+
+	    if ( isfield(opt, 'verbose') )
+	        VERBOSE  = opt.verbose;
+	    end
         end
     end
 
@@ -98,8 +108,10 @@ function x = shifter(a, b, f, opt)
     function report
         % Synopsis: Reports to the user if the method has been successful.
         if ( n ~= MAX_ITER )
-            fprintf('%s Method:\n', name)
-            fprintf('>> Solution found in %d iterations\n', n)
+	    if (VERBOSE)
+                fprintf('%s Method:\n', name)
+                fprintf('>> Solution found in %d iterations\n', n)
+	    end
         else
             errID  = 'NonlinearSolver:ConvergenceException';
             errMSG = 'requires additional iterations for convergence';

--- a/nonlinear-equation-solvers/matlab/shifter.m
+++ b/nonlinear-equation-solvers/matlab/shifter.m
@@ -101,8 +101,11 @@ function x = shifter(a, b, f, opt)
             fprintf('%s Method:\n', name)
             fprintf('>> Solution found in %d iterations\n', n)
         else
-            fprintf('>> maximum number of iterations reached, ')
-            fprintf('try again with a narrower interval\n')
+            errID  = 'NonlinearSolver:ConvergenceException';
+            errMSG = 'requires additional iterations for convergence';
+            errMSG = [name, ' method ', errMSG];
+            except = MException(errID, errMSG);
+            throw(except);
         end
     end
 

--- a/nonlinear-equation-solvers/matlab/test.m
+++ b/nonlinear-equation-solvers/matlab/test.m
@@ -38,7 +38,7 @@ f = @(x) 1.0 / sqrt(x) + 2.0 * log10(0.024651/3.7 + ...
 
 % solves for the root of f(x) numerically
 %[ configuration struct (optional) ]%
-opt = struct('tol', 1.0e-12, 'max_iter', 256);
+opt = struct('tol', 1.0e-12, 'max_iter', 256, 'verbose', 0);
 x = bisect (a, b, f, opt)	% Bisection
 x = regfal (a, b, f, opt)	% Regula Falsi (or False Position)
 x = shifter(a, b, f, opt)	% Shifter Method

--- a/nonlinear-equation-solvers/python/nlsolvers.py
+++ b/nonlinear-equation-solvers/python/nlsolvers.py
@@ -58,7 +58,7 @@ def bisect(bounds, f, **kwargs):
         n += 1
 
 
-    report(n, name)
+    report(max_iter, n, name)
     return x
 
 
@@ -85,7 +85,7 @@ def regfal(bounds, f, **kwargs):
         n += 1
 
 
-    report(n, name)
+    report(max_iter, n, name)
     return x
 
 
@@ -114,7 +114,7 @@ def shifter(bounds, f, **kwargs):
         n += 1
 
 
-    report(n, name)
+    report(max_iter, n, name)
     return x
 
 
@@ -150,9 +150,9 @@ def optset(**kwargs):
     return (tol, max_iter)
 
 
-def report(it, name):
+def report(max_iter, it, name):
     """ Synopsis: Reports if the method has been successful. """
-    if (it != MAX_ITER):
+    if (it != max_iter):
         print(name + " Method:")
         print(f"solution found in {it} iterations")
     else:

--- a/nonlinear-equation-solvers/python/nlsolvers.py
+++ b/nonlinear-equation-solvers/python/nlsolvers.py
@@ -29,16 +29,16 @@ from numpy import abs
 
 
 # sets default values for the tolerance and maximum number of iterations
-TOL, MAX_ITER = (1.0e-8, 100)
+TOL, MAX_ITER, VERBOSE = (1.0e-8, 100, False)
 # defines options for nonlinear solvers
-nls_opts = {'tol': TOL, 'max_iter': MAX_ITER}
+nls_opts = {'tol': TOL, 'max_iter': MAX_ITER, 'verbose': VERBOSE}
 
 
 def bisect(bounds, f, **kwargs):
     """ Synopsis: Possible implementation of the Bisection method. """
 
     optional = kwargs.get('opts', None)
-    (tol, max_iter) = optset(opts = optional)
+    (tol, max_iter, verbose) = optset(opts = optional)
 
     name = "Bisection"
     check_bracket(name, bounds, f)
@@ -58,7 +58,7 @@ def bisect(bounds, f, **kwargs):
         n += 1
 
 
-    report(max_iter, n, name)
+    report(max_iter, n, name, verbose)
     return x
 
 
@@ -66,7 +66,7 @@ def regfal(bounds, f, **kwargs):
     """ Synopsis: Possible implementation of the Regula Falsi method. """
 
     optional = kwargs.get('opts', None)
-    (tol, max_iter) = optset(opts = optional)
+    (tol, max_iter, verbose) = optset(opts = optional)
 
     name = "Regula Falsi"
     check_bracket(name, bounds, f)
@@ -85,7 +85,7 @@ def regfal(bounds, f, **kwargs):
         n += 1
 
 
-    report(max_iter, n, name)
+    report(max_iter, n, name, verbose)
     return x
 
 
@@ -95,7 +95,7 @@ def shifter(bounds, f, **kwargs):
     """
 
     optional = kwargs.get('opts', None)
-    (tol, max_iter) = optset(opts = optional)
+    (tol, max_iter, verbose) = optset(opts = optional)
 
     name = "Shifter"
     check_bracket(name, bounds, f)
@@ -114,7 +114,7 @@ def shifter(bounds, f, **kwargs):
         n += 1
 
 
-    report(max_iter, n, name)
+    report(max_iter, n, name, verbose)
     return x
 
 
@@ -143,18 +143,21 @@ def optset(**kwargs):
     if (opts == None):
         tol      = TOL
         max_iter = MAX_ITER
+        verbose  = VERBOSE
     else:
         tol = opts['tol']
         max_iter = opts['max_iter']
+        verbose  = opts['verbose']
 
-    return (tol, max_iter)
+    return (tol, max_iter, verbose)
 
 
-def report(max_iter, it, name):
+def report(max_iter, it, name, verbose):
     """ Synopsis: Reports if the method has been successful. """
     if (it != max_iter):
-        print(name + " Method:")
-        print(f"solution found in {it} iterations")
+        if verbose:
+            print(name + " Method:")
+            print(f"solution found in {it} iterations")
     else:
         errMSG = (name + " " + "method requires more iterations for " +
                   "convergence")

--- a/nonlinear-equation-solvers/python/nlsolvers.py
+++ b/nonlinear-equation-solvers/python/nlsolvers.py
@@ -145,9 +145,21 @@ def optset(**kwargs):
         max_iter = MAX_ITER
         verbose  = VERBOSE
     else:
-        tol = opts['tol']
-        max_iter = opts['max_iter']
-        verbose  = opts['verbose']
+
+        if 'tol' in opts:
+            tol = opts['tol']
+        else:
+            tol = TOL
+
+        if 'max_iter' in opts:
+            max_iter = opts['max_iter']
+        else:
+            max_iter = MAX_ITER
+
+        if 'verbose' in opts:
+            verbose  = opts['verbose']
+        else:
+            verbose  = VERBOSE
 
     return (tol, max_iter, verbose)
 

--- a/nonlinear-equation-solvers/python/nlsolvers.py
+++ b/nonlinear-equation-solvers/python/nlsolvers.py
@@ -156,8 +156,9 @@ def report(max_iter, it, name):
         print(name + " Method:")
         print(f"solution found in {it} iterations")
     else:
-        print(f"method failed to find the root you may try " +
-              f"a narrower interval")
+        errMSG = (name + " " + "method requires more iterations for " +
+                  "convergence")
+        raise RuntimeError(errMSG)
     return
 
 

--- a/nonlinear-equation-solvers/python/test_nlsolvers.py
+++ b/nonlinear-equation-solvers/python/test_nlsolvers.py
@@ -33,6 +33,7 @@ options = nls_opts
 # overrides defaults
 options['tol']      = 1.0e-12
 options['max_iter'] = 256
+options['verbose']  = False
 
 bounds = (1.0e-2, 9.0e-2)   # bracketing interval [a, b]
 


### PR DESCRIPTION
The nonlinear solvers can operate in quite mode. The user can enable/disable messages from the solver via the configuration struct. 

The code either raises an exception or aborts execution if the method does not converge with the allowed number of iterations. This is particularly important when using the solver for numerical integration of ordinary differential equations via implicit methods. You really do not want to use the returned value if the convergence has not occurred. You also do not want to see messages from the nonlinear solver unless you are testing. So it's important to be able to suppress messages when needed.

Have I tested the code more thoroughly when adding support for the configuration struct the BUG would have been detected then.